### PR TITLE
Add a function to set vertical flip state

### DIFF
--- a/example/render.cpp
+++ b/example/render.cpp
@@ -19,7 +19,6 @@ void process_input(GLFWwindow *window) {
 }
 
 auto main(int argc, char **argv) -> int {
-
     if (argc == 1) {
         std::cerr << "Usage: ./render [file]" << std::endl;
         return 1;
@@ -28,7 +27,7 @@ auto main(int argc, char **argv) -> int {
     std::string file = argv[1];
     std::ifstream file_in(file);
 
-    if(!file_in.is_open())
+    if (!file_in.is_open())
         throw std::iostream::failure("Could not open " + file);
 
     // glfw: initialize and configure
@@ -49,13 +48,14 @@ auto main(int argc, char **argv) -> int {
     glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 
     // glad: load OpenGL function pointers
-    if (gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress)) == 0) {
+    if (gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))
+      == 0) {
         std::cout << "Failed to initialize GLAD" << std::endl;
         return -1;
     }
 
-
     bresenham::figure fig(screen_width, screen_height);
+    // fig.flip_vertically(true);
     file_in >> fig;
 
     // render loop

--- a/example/render.cpp
+++ b/example/render.cpp
@@ -55,7 +55,7 @@ auto main(int argc, char **argv) -> int {
     }
 
     bresenham::figure fig(screen_width, screen_height);
-    // fig.flip_vertically(true);
+    fig.flip_vertically(true);
     file_in >> fig;
 
     // render loop

--- a/include/bresenham/bresenham.h
+++ b/include/bresenham/bresenham.h
@@ -67,7 +67,12 @@ class figure {
      */
     figure(uint width, uint height);
 
-        void flip_vertically(bool flip);
+    /**
+     * @brief Sets the state so that all figures drawn are flipped vertically.
+     * 
+     * @param flip A boolean that tells whether to set the flip state.
+     */
+    void flip_vertically(bool flip);
 
     /**
      * \brief Sets the pixel drawing color `m_rgb`.

--- a/include/bresenham/bresenham.h
+++ b/include/bresenham/bresenham.h
@@ -67,6 +67,8 @@ class figure {
      */
     figure(uint width, uint height);
 
+        void flip_vertically(bool flip);
+
     /**
      * \brief Sets the pixel drawing color `m_rgb`.
      *
@@ -149,6 +151,7 @@ class figure {
    private:
     /// An internal function to get the color of a pixel at given coordinates
     auto get_pixel_color(uint x, uint y) -> color;
+    bool m_flip = false;
 
    protected:
     uint m_width;  ///< The width of the screen in pixels.

--- a/src/bresenham/bresenham.cpp
+++ b/src/bresenham/bresenham.cpp
@@ -8,6 +8,8 @@
 bresenham::figure::figure(uint width, uint height)
   : m_width(width), m_height(height), m_pixel_buffer(width * height * 3, 255) {}
 
+void bresenham::figure::flip_vertically(bool flip) { m_flip = flip; }
+
 void bresenham::figure::set_color(color rgb) { m_rgb = rgb; }
 
 auto bresenham::figure::get_pixel_color(uint x, uint y) -> bresenham::color {
@@ -18,6 +20,8 @@ auto bresenham::figure::get_pixel_color(uint x, uint y) -> bresenham::color {
 
 void bresenham::figure::add_pixel(uint x, uint y) {
     if (x >= m_width || y >= m_height) return;
+
+    if (m_flip) y = m_height - y;
 
     uint pos = (x + y * m_width) * 3;
     m_pixel_buffer[pos] = m_rgb.r;
@@ -68,7 +72,8 @@ std::istream &operator>>(std::istream &in, bresenham::figure &fig) {
             ss >> cx >> cy >> a >> b;
             fig.add_ellipse(cx, cy, a, b);
         } else if (op == "fill") {
-            uint x, y, r, g, b;
+            uint x, y;
+            uint r, g, b;
             ss >> x >> y >> r >> g >> b;
             fig.fill(x, y, {r, g, b});
         } else {

--- a/src/bresenham/bresenham.cpp
+++ b/src/bresenham/bresenham.cpp
@@ -21,7 +21,7 @@ auto bresenham::figure::get_pixel_color(uint x, uint y) -> bresenham::color {
 void bresenham::figure::add_pixel(uint x, uint y) {
     if (x >= m_width || y >= m_height) return;
 
-    if (m_flip) y = m_height - y;
+    if (m_flip) y = m_height - y - 1;
 
     uint pos = (x + y * m_width) * 3;
     m_pixel_buffer[pos] = m_rgb.r;
@@ -30,9 +30,16 @@ void bresenham::figure::add_pixel(uint x, uint y) {
 }
 
 void bresenham::figure::fill(uint ix, uint iy, color boundary_color) {
-    if (ix >= m_width || iy >= m_height || m_rgb == get_pixel_color(ix, iy)
-      || boundary_color == get_pixel_color(ix, iy))
-        return;
+    if (m_flip) {
+        if (ix >= m_width || iy >= m_height
+          || m_rgb == get_pixel_color(ix, m_height - iy - 1)
+          || boundary_color == get_pixel_color(ix, m_height - iy - 1))
+            return;
+    } else {
+        if (ix >= m_width || iy >= m_height || m_rgb == get_pixel_color(ix, iy)
+          || boundary_color == get_pixel_color(ix, iy))
+            return;
+    }
 
     add_pixel(ix, iy);
 


### PR DESCRIPTION
The coordinates in the examples are given in Paint coordinates. In paint origin is at top left and not bottom left, so all images drawn need to be flipped vertically.